### PR TITLE
fix 'Netd : Unable to start DnsProxyListner' boot loop

### DIFF
--- a/files/init.rc
+++ b/files/init.rc
@@ -349,6 +349,7 @@ service vold /system/bin/vold
 
 service netd /system/bin/netd
     socket netd stream 0660 root system
+    socket dnsproxyd stream 0660 root inet
 
 service debuggerd /system/bin/debuggerd
 

--- a/files/init.thunderg.rc
+++ b/files/init.thunderg.rc
@@ -126,6 +126,10 @@ service iprenew_wlan0 /system/bin/dhcpcd -n wlan0
     disabled
     oneshot
 
+service netd /system/bin/netd
+    socket netd stream 0660 root system
+    socket dnsproxyd stream 0660 root inet
+
 service dhcpcd_wlan0 /system/bin/dhcpcd -BKL wlan0
     disabled
     oneshot

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -124,5 +124,5 @@
     <!-- The orientation in which case volume buttins should be swapped.
          See ROTATION_0, ROTATION_90, ROTATION_180, ROTATION_270 in android.view.Surface
          for more details about values -->
-    <integer name="swap_volume_keys_orientation">1</integer>
+    <!-- <integer name="swap_volume_keys_orientation">1</integer> -->
 </resources>


### PR DESCRIPTION
Updates to CyanogenMod/android_system_netd break thunderg builds
